### PR TITLE
Added password visibility toggle button

### DIFF
--- a/pages/login.js
+++ b/pages/login.js
@@ -11,6 +11,7 @@ export default function LoginPage() {
   const [password, setPassword] = useState("");
   const [role, setRole] = useState("doctor");
   const [darkMode, setDarkMode] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
 
   // Initialize dark mode
   useEffect(() => {
@@ -139,23 +140,66 @@ export default function LoginPage() {
               }}>
                 PASSWORD
               </label>
-              <input
-                type="password"
-                placeholder="Password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                style={{
-                  width: "100%",
-                  padding: "10px",
-                  border: darkMode ? "1px solid #4a5568" : "1px solid #e2e8f0",
-                  borderRadius: "6px",
-                  background: darkMode ? "#2d3748" : "#f7fafc",
-                  color: darkMode ? "#ffffff" : "#2d3748",
-                  fontSize: "14px",
-                  outline: "none",
-                }}
-                required
-              />
+              <div style={{ position: "relative" }}>
+                <input
+                  type={showPassword ? "text" : "password"}
+                  placeholder="Password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  style={{
+                    width: "100%",
+                    padding: "10px 40px 10px 10px",
+                    border: darkMode ? "1px solid #4a5568" : "1px solid #e2e8f0",
+                    borderRadius: "6px",
+                    background: darkMode ? "#2d3748" : "#f7fafc",
+                    color: darkMode ? "#ffffff" : "#2d3748",
+                    fontSize: "14px",
+                    outline: "none",
+                  }}
+                  required
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  style={{
+                    position: "absolute",
+                    right: "10px",
+                    top: "50%",
+                    transform: "translateY(-50%)",
+                    background: "none",
+                    border: "none",
+                    cursor: "pointer",
+                    color: darkMode ? "#a0aec0" : "#718096",
+                    padding: "4px",
+                    borderRadius: "4px",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    width: "24px",
+                    height: "24px",
+                  }}
+                  onMouseEnter={(e) => {
+                    e.target.style.color = darkMode ? "#e2e8f0" : "#4a5568";
+                    e.target.style.background = darkMode ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.05)";
+                  }}
+                  onMouseLeave={(e) => {
+                    e.target.style.color = darkMode ? "#a0aec0" : "#718096";
+                    e.target.style.background = "none";
+                  }}
+                >
+                  {showPassword ? (
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path>
+                      <line x1="1" y1="1" x2="23" y2="23"></line>
+                    </svg>
+                  ) : (
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+                      <circle cx="12" cy="12" r="3"></circle>
+                    </svg>
+                  )}
+                </button>
+              </div>
             </div>
 
             {/* Role Selection - Compact */}


### PR DESCRIPTION
## 📝 Description

**Linked Issue:** #161 

---

## 🏗️ Type of Change
Select the relevant option:
- [x] 🚀 **New Feature** (Addition of a new functionality)
- [ ] 🐛 **Bug Fix** (Logic or functional error)
- [x] 🎨 **UI/UX Update** (Changes to the interface/accessibility)
- [ ] 📝 **Documentation** (README or Wiki updates)
- [ ] 🔧 **Refactor/Cleanup** (No functional changes)

---

## ⚙️ Technical Checklist
- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md).
- [x] My code follows the project's style guidelines and PEP 8.
- [ ] **Firebase/Auth:** If I modified backend logic, I have verified it works.
- [x] I have performed a self-review and added comments to complex code.
- [x] My changes generate no new warnings or errors.

---

## 🧪 Testing & Evidence
- **Test Environment:** (e.g., Windows 11, Python 3.12)
- **Results:**
Eye Icon: Clear visual indicator
Toggle Functionality: Click to show/hide password
Hover Effects: Interactive feedback
Dark Mode Support: Works in both themes

---

## 📸 Screenshots / Media
>

https://github.com/user-attachments/assets/fddbd09d-7978-4a1e-afcf-d4fa7ac8640d


---

## ❄️ SWOC '26 Status
- [x] I am a contributor for **Social Winter of Code 2026**.
- [ ] This is my first contribution to this project.

---
*By submitting this PR, I agree to maintain the standards of Chameleon. 🦎*
