### PR TITLE
fix: allow public access to appointments, monitoring, and prescriptio…

### DIFF
--- a/pages/layout.js
+++ b/pages/layout.js
@@ -36,7 +36,7 @@ export default function Layout({ children }) {
     if (!mounted) return;
 
     const userType = getUserType();
-    const publicPages = ["/", "/login", "/signup", "/signup-test", "/faq", "/contact", "/about", "/privacy", "/terms", "/how-it-works", "/open-source", "/support"];
+    const publicPages = ["/", "/login", "/signup", "/signup-test", "/faq", "/contact", "/about", "/privacy", "/terms", "/how-it-works", "/open-source", "/support", "/appointments", "/monitoring", "/prescriptions"];
 
     // Convert pathname to string for comparison
     const currentPath = pathname || "";


### PR DESCRIPTION
## 📝 Description
Fixed the issue where clicking on Appointments, Monitoring, and Prescriptions in the navbar always redirected to the Login page instead of opening their respective pages.

**Linked Issue:** #235 

## 🏗️ Type of Change
Select the relevant option:
- [ ] 🚀 **New Feature** (Addition of a new functionality)
- [x] 🐛 **Bug Fix** (Logic or functional error)
- [ ] 🎨 **UI/UX Update** (Changes to the interface/accessibility)
- [ ] 📝 **Documentation** (README or Wiki updates)
- [ ] 🔧 **Refactor/Cleanup** (No functional changes)

---

## ⚙️ Technical Checklist
- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md).
- [x] My code follows the project's style guidelines and PEP 8.
- [ ] **Firebase/Auth:** If I modified backend logic, I have verified it works.
- [x] I have performed a self-review and added comments to complex code.
- [x] My changes generate no new warnings or errors.

---

## 🧪 Testing & Evidence
- **Test Environment:** Ubuntu 22.04, Node.js 18
- **Results:**  
  Verified that Appointments, Monitoring, and Prescriptions now correctly navigate to their respective pages instead of redirecting to the Login page.

---

## 📸 Screenshots / Media
<img width="1862" height="964" alt="image" src="https://github.com/user-attachments/assets/ac0b9070-e4bd-4c55-a258-609f868f8f15" />

<img width="1862" height="964" alt="image" src="https://github.com/user-attachments/assets/a7f9c7c6-2cb9-423d-bd9a-05ccf403a0d6" />


<img width="1862" height="964" alt="image" src="https://github.com/user-attachments/assets/44b84955-40ee-4d8b-b648-dd81155a21e4" />


(Before: All three links opened Login page)  
(After: Each link opens its correct page)

---

## ❄️ SWOC '26 Status
- [x] I am a contributor for **Social Winter of Code 2026**
