### PR TITLE
Fix-Toggle-icon-appearance

### DIFF
--- a/components/ThemeToggle.js
+++ b/components/ThemeToggle.js
@@ -8,13 +8,13 @@ export default function ThemeToggle() {
   return (
     <button
       onClick={toggleTheme}
-      className="theme-toggle-button p-2 rounded-full focus:outline-none transition-colors hover:bg-gray-200 dark:hover:bg-gray-700"
+      className="theme-toggle-button p-2 rounded-full focus:outline-none transition-colors hover:bg-gray-700 dark:hover:bg-gray-700"
       aria-label="Toggle dark mode"
     >
       {theme === 'dark' ? (
         <SunIcon className="w-5 h-5 text-yellow-300" />
       ) : (
-        <MoonIcon className="w-5 h-5 text-gray-700 dark:text-gray-300" />
+        <MoonIcon className="w-5 h-5 text-gray-100 dark:text-gray-300" />
       )}
     </button>
   )


### PR DESCRIPTION
## 📝 Description


Toggle Icon was not visible in navbar making it confusing for users to find it. Gave white color to its borders to make it appear in navbar.

**Linked Issue:** ---


#243 


## 🏗️ Type of Change
Select the relevant option:
- [ ] 🚀 **New Feature** (Addition of a new functionality)
- [x] 🐛 **Bug Fix** (Logic or functional error)
- [ ] 🎨 **UI/UX Update** (Changes to the interface/accessibility)
- [ ] 📝 **Documentation** (README or Wiki updates)
- [ ] 🔧 **Refactor/Cleanup** (No functional changes)

---

## ⚙️ Technical Checklist
- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md).
- [x] My code follows the project's style guidelines and PEP 8.
- [ ] **Firebase/Auth:** If I modified backend logic, I have verified it works.
- [x] I have performed a self-review and added comments to complex code.
- [x] My changes generate no new warnings or errors.

---

## 🧪 Testing & Evidence
- **Test Environment:** ( Windows 11)
- **Results:** 
the code run successfully and the icon is clearly visible

---

## 📸 Screenshots / Media
<img width="1899" height="964" alt="image" src="https://github.com/user-attachments/assets/74eedf49-8cd6-4c66-a470-391b589f153a" />

---

## ❄️ SWOC '26 Status
- [x] I am a contributor for **Social Winter of Code 2026**.
- [x] This is my first contribution to this project.

---
*By submitting this PR, I agree to maintain the standards of Chameleon. 🦎*
