### PR TITLE
fix-Toggle-icon-color

### DIFF
--- a/components/ThemeToggle.js
+++ b/components/ThemeToggle.js
@@ -8,13 +8,13 @@ export default function ThemeToggle() {
   return (
     <button
       onClick={toggleTheme}
-      className="theme-toggle-button p-2 rounded-full focus:outline-none transition-colors hover:bg-gray-200 dark:hover:bg-gray-700"
+      className="theme-toggle-button p-2 rounded-full focus:outline-none transition-colors hover:bg-gray-700 dark:hover:bg-gray-300"
       aria-label="Toggle dark mode"
     >
       {theme === 'dark' ? (
         <SunIcon className="w-5 h-5 text-yellow-300" />
       ) : (
-        <MoonIcon className="w-5 h-5 text-gray-700 dark:text-gray-300" />
+        <MoonIcon className="w-5 h-5 text-gray-200 dark:text-gray-300" />
       )}
     </button>
   )


### PR DESCRIPTION
## 📝 Description
The Toggle icon is not visible clearly on Navbar due to color contrast fixed it by giving proper colours.


**Linked Issue:** ---

Fixes #243 


## 🏗️ Type of Change
Select the relevant option:
- [ ] 🚀 **New Feature** (Addition of a new functionality)
- [ ] 🐛 **Bug Fix** (Logic or functional error)
- [x] 🎨 **UI/UX Update** (Changes to the interface/accessibility)
- [ ] 📝 **Documentation** (README or Wiki updates)
- [ ] 🔧 **Refactor/Cleanup** (No functional changes)

---

## ⚙️ Technical Checklist
- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md).
- [x] My code follows the project's style guidelines and PEP 8.
- [ ] **Firebase/Auth:** If I modified backend logic, I have verified it works.
- [x] I have performed a self-review and added comments to complex code.
- [x] My changes generate no new warnings or errors.

---

## 🧪 Testing & Evidence
- **Test Environment:** ( Windows 11)
- **Results:** (Describe what happened when you ran the code)

## ScreenShots

Before
<img width="1883" height="915" alt="Screenshot 2026-02-01 225637" src="https://github.com/user-attachments/assets/57e0457a-96ba-485f-97c8-33b5b2567812" />


After
<img width="1883" height="638" alt="image" src="https://github.com/user-attachments/assets/bcc7af7d-a48c-4b80-b7ba-c6352546b3da" />


---

## ❄️ SWOC '26 Status
- [x] I am a contributor for **Social Winter of Code 2026**.
- [x] This is my first contribution to this project.

---
*By submitting this PR, I agree to maintain the standards of Chameleon. 🦎*
