### PR TITLE
Add ARIA labels and keyboard navigation

### DIFF
--- a/pages/admin/support-management.js
+++ b/pages/admin/support-management.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { 
+import {
   FaTicketAlt, FaUsers, FaClock, FaCheckCircle, FaExclamationTriangle,
   FaFilter, FaSearch, FaDownload, FaEye, FaReply, FaArchive, FaTrash,
   FaUserPlus, FaChartLine, FaBell, FaCog, FaSignOutAlt, FaHeadset,
@@ -32,7 +32,7 @@ const AdminSupportManagement = () => {
     // Subscribe to real-time ticket updates
     const unsubscribe = getSupportTickets((updatedTickets) => {
       setTickets(updatedTickets);
-      
+
       // Update statistics
       const stats = {
         total: updatedTickets.length,
@@ -46,7 +46,7 @@ const AdminSupportManagement = () => {
           return ticketDate.toDateString() === today.toDateString();
         }).length
       };
-      
+
       setSystemStats(prev => ({
         ...prev,
         ...stats,
@@ -75,7 +75,7 @@ const AdminSupportManagement = () => {
   const unreadNotifications = notifications.filter(n => !n.read).length;
 
   const handleNotificationClick = (notificationId) => {
-    setNotifications(prev => 
+    setNotifications(prev =>
       prev.map(n => n.id === notificationId ? { ...n, read: true } : n)
     );
   };
@@ -107,7 +107,7 @@ const AdminSupportManagement = () => {
     const now = new Date();
     const date = timestamp?.toDate ? timestamp.toDate() : new Date(timestamp);
     const diffInHours = Math.floor((now - date) / (1000 * 60 * 60));
-    
+
     if (diffInHours < 1) return 'Just now';
     if (diffInHours < 24) return `${diffInHours}h ago`;
     if (diffInHours < 48) return 'Yesterday';
@@ -119,6 +119,22 @@ const AdminSupportManagement = () => {
     setShowReplyModal(true);
     setReplyMessage('');
   };
+
+  // Keyboard navigation: Close modal on Escape key
+  useEffect(() => {
+    const handleEscapeKey = (event) => {
+      if (event.key === 'Escape' && showReplyModal) {
+        setShowReplyModal(false);
+      }
+    };
+
+    if (showReplyModal) {
+      document.addEventListener('keydown', handleEscapeKey);
+      return () => {
+        document.removeEventListener('keydown', handleEscapeKey);
+      };
+    }
+  }, [showReplyModal]);
 
   const handleSendReply = async () => {
     if (!replyMessage.trim() || !selectedTicket) return;
@@ -141,7 +157,7 @@ const AdminSupportManagement = () => {
       console.log('AdminDashboard: Calling addTicketMessage with:', messageData);
       const result = await addTicketMessage(selectedTicket.id, messageData);
       console.log('AdminDashboard: addTicketMessage result:', result);
-      
+
       if (result.success) {
         // Update ticket status to in_progress if it was open
         if (selectedTicket.status === 'open') {
@@ -156,7 +172,7 @@ const AdminSupportManagement = () => {
         setShowReplyModal(false);
         setReplyMessage('');
         setSelectedTicket(null);
-        
+
         // Show success notification
         alert('Reply sent successfully!');
       } else {
@@ -176,7 +192,7 @@ const AdminSupportManagement = () => {
 
     try {
       console.log('AdminDashboard: Closing ticket:', ticket.id);
-      
+
       // Add closing message
       const closingMessage = {
         type: 'agent',
@@ -189,14 +205,14 @@ const AdminSupportManagement = () => {
       };
 
       const messageResult = await addTicketMessage(ticket.id, closingMessage);
-      
+
       if (messageResult.success) {
         // Update ticket status to resolved
         const statusResult = await updateTicketStatus(ticket.id, 'resolved', {
           name: 'Support Agent',
           avatar: '👨‍⚕️'
         });
-        
+
         if (statusResult.success) {
           alert(`Ticket ${ticket.id} has been successfully closed.`);
         } else {
@@ -222,11 +238,19 @@ const AdminSupportManagement = () => {
       <div className={styles.header}>
         <h2>Support Management Dashboard</h2>
         <div className={styles.headerActions}>
-          <button className={styles.exportBtn}>
-            <FaDownload /> Export Report
+          <button
+            className={styles.exportBtn}
+            type="button"
+            aria-label="Export support tickets report"
+          >
+            <FaDownload aria-hidden="true" /> Export Report
           </button>
-          <button className={styles.settingsBtn}>
-            <FaCog /> Settings
+          <button
+            className={styles.settingsBtn}
+            type="button"
+            aria-label="Open settings"
+          >
+            <FaCog aria-hidden="true" /> Settings
           </button>
         </div>
       </div>
@@ -283,15 +307,23 @@ const AdminSupportManagement = () => {
         <div className={styles.dashboardHeader}>
           <h3>Recent Support Tickets</h3>
           <div className={styles.dashboardActions}>
-            <button className={styles.refreshBtn}>
-              <FaClock /> Refresh
+            <button
+              className={styles.refreshBtn}
+              type="button"
+              aria-label="Refresh ticket list"
+            >
+              <FaClock aria-hidden="true" /> Refresh
             </button>
-            <button className={styles.exportBtn}>
-              <FaDownload /> Export
+            <button
+              className={styles.exportBtn}
+              type="button"
+              aria-label="Export tickets to file"
+            >
+              <FaDownload aria-hidden="true" /> Export
             </button>
           </div>
         </div>
-        
+
         <div className={styles.ticketsGrid}>
           {tickets.length === 0 ? (
             <div className={styles.emptyState}>
@@ -323,9 +355,9 @@ const AdminSupportManagement = () => {
                     </span>
                   </div>
                 </div>
-                
+
                 <h4 className={styles.ticketSubject}>{ticket.subject || 'No Subject'}</h4>
-                
+
                 <div className={styles.ticketUser}>
                   <span className={styles.userAvatar}>{ticket.user?.avatar || '👤'}</span>
                   <div>
@@ -333,7 +365,7 @@ const AdminSupportManagement = () => {
                     <div className={styles.userEmail}>{ticket.user?.email || 'No Email'}</div>
                   </div>
                 </div>
-                
+
                 <div className={styles.ticketFooter}>
                   <div className={styles.tags}>
                     {(ticket.tags || []).map((tag, index) => (
@@ -349,26 +381,32 @@ const AdminSupportManagement = () => {
                     </div>
                   )}
                 </div>
-                
+
                 <div className={styles.ticketActions}>
-                  <button 
+                  <button
                     onClick={() => handleViewDetails(ticket)}
                     className={styles.viewBtn}
+                    type="button"
+                    aria-label={`View details for ticket ${ticket.id}`}
                   >
-                    <FaEye /> View
+                    <FaEye aria-hidden="true" /> View
                   </button>
-                  <button 
+                  <button
                     onClick={() => handleReplyClick(ticket)}
                     className={styles.replyBtn}
+                    type="button"
+                    aria-label={`Reply to ticket ${ticket.id}`}
                   >
-                    <FaReply /> Reply
+                    <FaReply aria-hidden="true" /> Reply
                   </button>
                   {ticket.status !== 'resolved' && (
-                    <button 
+                    <button
                       onClick={() => handleCloseTicket(ticket)}
                       className={styles.closeBtn}
+                      type="button"
+                      aria-label={`Close ticket ${ticket.id}`}
                     >
-                      <FaCheckCircle /> Close
+                      <FaCheckCircle aria-hidden="true" /> Close
                     </button>
                   )}
                 </div>
@@ -376,12 +414,14 @@ const AdminSupportManagement = () => {
             ))
           )}
         </div>
-        
+
         {tickets.length > 6 && (
           <div className={styles.viewAllContainer}>
-            <button 
+            <button
               onClick={() => setActiveView('dashboard')}
               className={styles.viewAllBtn}
+              type="button"
+              aria-label={`View all ${tickets.length} support tickets`}
             >
               View All {tickets.length} Tickets
             </button>
@@ -395,8 +435,12 @@ const AdminSupportManagement = () => {
     <div className={styles.agentsView}>
       <div className={styles.header}>
         <h2>Agent Management</h2>
-        <button className={styles.addAgentBtn}>
-          <FaUserPlus /> Add Agent
+        <button
+          className={styles.addAgentBtn}
+          type="button"
+          aria-label="Add new support agent"
+        >
+          <FaUserPlus aria-hidden="true" /> Add Agent
         </button>
       </div>
 
@@ -452,14 +496,26 @@ const AdminSupportManagement = () => {
             </div>
 
             <div className={styles.agentActions}>
-              <button className={styles.viewBtn}>
-                <FaEye /> View Details
+              <button
+                className={styles.viewBtn}
+                type="button"
+                aria-label={`View details for agent ${agent.name}`}
+              >
+                <FaEye aria-hidden="true" /> View Details
               </button>
-              <button className={styles.messageBtn}>
-                <FaReply /> Message
+              <button
+                className={styles.messageBtn}
+                type="button"
+                aria-label={`Send message to ${agent.name}`}
+              >
+                <FaReply aria-hidden="true" /> Message
               </button>
-              <button className={styles.editBtn}>
-                <FaCog /> Edit
+              <button
+                className={styles.editBtn}
+                type="button"
+                aria-label={`Edit agent ${agent.name}`}
+              >
+                <FaCog aria-hidden="true" /> Edit
               </button>
             </div>
           </motion.div>
@@ -473,8 +529,9 @@ const AdminSupportManagement = () => {
       <div className={styles.header}>
         <h2>Support Analytics</h2>
         <div className={styles.dateFilter}>
-          <FaCalendarAlt />
-          <select>
+          <FaCalendarAlt aria-hidden="true" />
+          <label htmlFor="analytics-date-range" className="sr-only">Select date range</label>
+          <select id="analytics-date-range" aria-label="Select date range for analytics">
             <option>Last 7 days</option>
             <option>Last 30 days</option>
             <option>Last 3 months</option>
@@ -570,9 +627,11 @@ const AdminSupportManagement = () => {
     <div className={styles.notificationsView}>
       <div className={styles.header}>
         <h2>Notifications</h2>
-        <button 
+        <button
           onClick={markAllNotificationsRead}
           className={styles.markReadBtn}
+          type="button"
+          aria-label="Mark all notifications as read"
         >
           Mark All Read
         </button>
@@ -715,19 +774,23 @@ const AdminSupportManagement = () => {
           <h2>Support Admin</h2>
         </div>
 
-        <nav className={styles.sidebarNav}>
+        <nav className={styles.sidebarNav} aria-label="Support admin navigation">
           {sidebarItems.map((item) => {
             const Icon = item.icon;
+            const isActive = activeView === item.id;
             return (
               <button
                 key={item.id}
                 onClick={() => setActiveView(item.id)}
-                className={`${styles.navItem} ${activeView === item.id ? styles.active : ''}`}
+                className={`${styles.navItem} ${isActive ? styles.active : ''}`}
+                type="button"
+                aria-label={item.label}
+                aria-current={isActive ? 'page' : undefined}
               >
-                <Icon className={styles.navIcon} />
+                <Icon className={styles.navIcon} aria-hidden="true" />
                 <span>{item.label}</span>
                 {item.id === 'notifications' && unreadNotifications > 0 && (
-                  <span className={styles.notificationBadge}>
+                  <span className={styles.notificationBadge} aria-label={`${unreadNotifications} unread notifications`}>
                     {unreadNotifications}
                   </span>
                 )}
@@ -737,8 +800,12 @@ const AdminSupportManagement = () => {
         </nav>
 
         <div className={styles.sidebarFooter}>
-          <button className={styles.logoutBtn}>
-            <FaSignOutAlt /> Logout
+          <button
+            className={styles.logoutBtn}
+            type="button"
+            aria-label="Logout from admin panel"
+          >
+            <FaSignOutAlt aria-hidden="true" /> Logout
           </button>
         </div>
       </div>
@@ -761,6 +828,9 @@ const AdminSupportManagement = () => {
             exit={{ opacity: 0 }}
             className={styles.modalOverlay}
             onClick={() => setShowReplyModal(false)}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="reply-modal-title"
           >
             <motion.div
               initial={{ scale: 0.9, opacity: 0 }}
@@ -770,12 +840,14 @@ const AdminSupportManagement = () => {
               onClick={(e) => e.stopPropagation()}
             >
               <div className={styles.modalHeader}>
-                <h3>Reply to Ticket</h3>
+                <h3 id="reply-modal-title">Reply to Ticket</h3>
                 <button
                   onClick={() => setShowReplyModal(false)}
                   className={styles.closeModal}
+                  type="button"
+                  aria-label="Close dialog"
                 >
-                  <FaTimes />
+                  <FaTimes aria-hidden="true" />
                 </button>
               </div>
 
@@ -802,15 +874,18 @@ const AdminSupportManagement = () => {
               </div>
 
               <div className={styles.replyForm}>
-                <label className={styles.replyLabel}>
+                <label htmlFor="reply-message" className={styles.replyLabel}>
                   Your Reply
                 </label>
                 <textarea
+                  id="reply-message"
                   value={replyMessage}
                   onChange={(e) => setReplyMessage(e.target.value)}
                   placeholder="Type your response here..."
                   className={styles.replyTextarea}
                   rows={6}
+                  aria-label="Type your reply message"
+                  aria-required="true"
                 />
               </div>
 
@@ -818,6 +893,8 @@ const AdminSupportManagement = () => {
                 <button
                   onClick={() => setShowReplyModal(false)}
                   className={styles.cancelBtn}
+                  type="button"
+                  aria-label="Cancel and close dialog"
                 >
                   Cancel
                 </button>
@@ -825,8 +902,10 @@ const AdminSupportManagement = () => {
                   onClick={handleSendReply}
                   disabled={!replyMessage.trim()}
                   className={styles.sendBtn}
+                  type="button"
+                  aria-label="Send reply to customer"
                 >
-                  <FaPaperPlane /> Send Reply
+                  <FaPaperPlane aria-hidden="true" /> Send Reply
                 </button>
               </div>
             </motion.div>

--- a/pages/admin/support-management.module.css
+++ b/pages/admin/support-management.module.css
@@ -1,4 +1,18 @@
 /* Admin Support Management Styles */
+
+/* Screen reader only utility class */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
 .adminSupport {
   display: flex;
   min-height: 100vh;


### PR DESCRIPTION
## Description
Added ARIA labels and keyboard navigation support to the admin support management page to improve accessibility and align with WCAG 2.1 guidelines.

---

## Changes
- Added `aria-label` to all buttons and interactive elements
- Marked decorative icons with `aria-hidden="true"`
- Implemented `Escape` key support to close modals
- Added proper modal accessibility attributes:
  - `role="dialog"`
  - `aria-modal="true"`
- Associated form labels with their corresponding inputs
- Added `.sr-only` CSS class for screen-reader-only content

---

## Testing
- ✅ Keyboard navigation works correctly
- ✅ Modal closes with `Escape` key
- ✅ No visual regressions observed

---

## Issue
Fixes #310
