### PR TITLE
fix: handle orphaned alerts by flagging as global and adding UI toggle

### DIFF
--- a/components/DoctorComponents/AlertHistory.js
+++ b/components/DoctorComponents/AlertHistory.js
@@ -18,11 +18,22 @@ export default function AlertHistory({ doctorId }) {
         setLoading(true);
 
         try {
-            let q = query(
-                collection(db, 'alerts'),
-                where('doctorId', '==', doctorId),
-                orderBy('createdAt', 'desc')
-            );
+            // Check if we want global/unassigned alerts
+            let q;
+
+            if (doctorId === 'unassigned') {
+                q = query(
+                    collection(db, 'alerts'),
+                    where('isGlobal', '==', true),
+                    orderBy('createdAt', 'desc')
+                );
+            } else {
+                q = query(
+                    collection(db, 'alerts'),
+                    where('doctorId', '==', doctorId),
+                    orderBy('createdAt', 'desc')
+                );
+            }
 
             // Apply date filter
             if (dateFilter !== 'all') {
@@ -99,9 +110,16 @@ export default function AlertHistory({ doctorId }) {
             <div className="flex items-center justify-between mb-6">
                 <div className="flex items-center gap-3">
                     <FaHistory className="text-blue-500" size={24} />
-                    <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
-                        Alert History
-                    </h2>
+                    <div>
+                        <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
+                            Alert History
+                        </h2>
+                        {doctorId === 'unassigned' && (
+                            <span className="text-sm bg-red-100 text-red-700 px-2 py-0.5 rounded-full border border-red-200">
+                                🚨 Unassigned / Emergency
+                            </span>
+                        )}
+                    </div>
                 </div>
 
                 <div className="flex items-center gap-2">

--- a/lib/alertSystem.js
+++ b/lib/alertSystem.js
@@ -10,7 +10,9 @@ export async function checkPatientVitals(patientData) {
     const alerts = [];
     const patientId = patientData.id || patientData.uid || patientData.phoneNumber;
     const patientName = patientData.name || 'Unknown Patient';
-    const doctorId = patientData.doctorId || patientData.assignedDoctor;
+    // 🚨 Critical Safety Fix: Handle unassigned patients
+    const doctorId = patientData.doctorId || patientData.assignedDoctor || 'unassigned';
+    const isGlobal = doctorId === 'unassigned';
 
     // Check heart rate
     if (patientData.heartRate || patientData.bpm) {
@@ -28,7 +30,8 @@ export async function checkPatientVitals(patientData) {
                 unit: 'bpm',
                 severity: result.severity,
                 message: result.message,
-                direction: result.direction
+                direction: result.direction,
+                isGlobal
             });
         }
     }
@@ -49,7 +52,8 @@ export async function checkPatientVitals(patientData) {
                 unit: '%',
                 severity: result.severity,
                 message: result.message,
-                direction: result.direction
+                direction: result.direction,
+                isGlobal
             });
         }
     }
@@ -70,7 +74,8 @@ export async function checkPatientVitals(patientData) {
                 unit: '°C',
                 severity: result.severity,
                 message: result.message,
-                direction: result.direction
+                direction: result.direction,
+                isGlobal
             });
         }
     }
@@ -93,7 +98,8 @@ export async function checkPatientVitals(patientData) {
                     unit: 'mmHg',
                     severity: systolicResult.severity,
                     message: systolicResult.message,
-                    direction: systolicResult.direction
+                    direction: systolicResult.direction,
+                    isGlobal
                 });
             }
 
@@ -110,7 +116,8 @@ export async function checkPatientVitals(patientData) {
                     unit: 'mmHg',
                     severity: diastolicResult.severity,
                     message: diastolicResult.message,
-                    direction: diastolicResult.direction
+                    direction: diastolicResult.direction,
+                    isGlobal
                 });
             }
         }
@@ -129,7 +136,8 @@ export async function saveAlert(alertData) {
             acknowledgedBy: null,
             createdAt: Timestamp.now(),
             // Add a readable timestamp for easier debugging
-            createdAtReadable: new Date().toLocaleString()
+            createdAtReadable: new Date().toLocaleString(),
+            isGlobal: alertData.isGlobal || false
         };
 
         const docRef = await addDoc(collection(db, 'alerts'), alertDoc);

--- a/pages/doctor/alerts.js
+++ b/pages/doctor/alerts.js
@@ -22,11 +22,40 @@ export default function AlertsPage() {
         }
     }, [router]);
 
+    const [viewMode, setViewMode] = useState('my'); // 'my' or 'unassigned'
+
     return (
         <AuthCheck>
             <DoctorSidebar>
                 <div className="p-4">
-                    {doctorId && <AlertHistory doctorId={doctorId} />}
+                    <div className="flex justify-end mb-4">
+                        <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-1 flex">
+                            <button
+                                onClick={() => setViewMode('my')}
+                                className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${viewMode === 'my'
+                                        ? 'bg-blue-500 text-white'
+                                        : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+                                    }`}
+                            >
+                                My Alerts
+                            </button>
+                            <button
+                                onClick={() => setViewMode('unassigned')}
+                                className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${viewMode === 'unassigned'
+                                        ? 'bg-red-500 text-white'
+                                        : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+                                    }`}
+                            >
+                                Unassigned Alerts
+                            </button>
+                        </div>
+                    </div>
+
+                    {doctorId && (
+                        <AlertHistory
+                            doctorId={viewMode === 'my' ? doctorId : 'unassigned'}
+                        />
+                    )}
                 </div>
             </DoctorSidebar>
         </AuthCheck>


### PR DESCRIPTION
## 🚑 Fix: Orphaned Alerts Safety Net

### 📝 Description
This PR addresses a critical safety vulnerability where emergency alerts for patients without an assigned doctor were being silently ignored. 

**Changes:**
1.  modified `lib/alertSystem.js` to flag alerts as `isGlobal: true` if the patient has no `doctorId`.
2.  Updated `components/DoctorComponents/AlertHistory.js` to support querying "Unassigned" alerts.
3.  Added a toggle in `pages/doctor/alerts.js` allowing any doctor to view "Unassigned / Emergency" alerts.

### 🐛 Issue Resolved
Fixes #439 - Critical Safety: Emergency Vital Alerts Silently Fail for Unassigned Patients
