### PR TITLE
Fix: Authentication redirect missing in SignIn.js

### DIFF
--- a/components/Auth/SignIn.js
+++ b/components/Auth/SignIn.js
@@ -1,9 +1,11 @@
 import { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
 
 export default function SignIn() {
   const [phone, setPhone] = useState('');
   const [otp, setOtp] = useState('');
   const [confirmation, setConfirmation] = useState(null);
+  const router = useRouter();
 
   // Initialize recaptcha once on mount
   useEffect(() => {
@@ -70,7 +72,7 @@ export default function SignIn() {
     try {
       await confirmation.confirm(otp);
       alert('Login successful!');
-      // TODO: redirect user based on your app logic
+      router.push('/patient');
     } catch (error) {
       alert('Incorrect OTP: ' + error.message);
     }


### PR DESCRIPTION
Issue:==#466


Description:

- Imported useRouter hook from next/router in the SignIn component.
- Initialized the router instance within the component.
- Added a redirection to the /patient route upon successful OTP verification.
- Resolved the TODO comment that indicated missing redirection logic.
- Verified that the user is now correctly navigated to the dashboard after logging in.