### PR TITLE
Fix support page buttons

### DIFF
--- a/components/Support/SupportWidget.js
+++ b/components/Support/SupportWidget.js
@@ -13,13 +13,13 @@ import { useTheme } from '@/context/ThemeContext';
 const localTicketCache = [];
 
 const SupportWidget = () => {
-  const { isMinimized, setIsMinimized, supportWidgetOpen, setSupportWidgetOpen } = useTheme();
+  const { isMinimized, setIsMinimized, supportWidgetOpen, setSupportWidgetOpen, showTicketModal, setShowTicketModal } = useTheme();
   const isOpen = supportWidgetOpen;
   const setIsOpen = setSupportWidgetOpen;
   const [messages, setMessages] = useState([]);
   const [inputValue, setInputValue] = useState('');
   const [isTyping, setIsTyping] = useState(false);
-  const [showTicketModal, setShowTicketModal] = useState(false);
+  
   const [currentTicket, setCurrentTicket] = useState(null);
   const [ticketData, setTicketData] = useState({
     subject: '',
@@ -81,6 +81,7 @@ const SupportWidget = () => {
         if (event.key === 'Escape') {
           event.preventDefault();
           setShowTicketModal(false);
+          setSupportWidgetOpen(false);
           inputRef.current?.focus();
         }
         return;
@@ -569,7 +570,10 @@ const SupportWidget = () => {
     return (
       <motion.button
         className={styles.widgetButton}
-        onClick={() => setIsOpen(true)}
+        onClick={() => {
+          setIsOpen(true);
+          setIsMinimized(false);
+        }}
         whileHover={{ scale: 1.05 }}
         whileTap={{ scale: 0.95 }}
       >
@@ -580,6 +584,7 @@ const SupportWidget = () => {
 
   return (
     <>
+      {!showTicketModal && (
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
@@ -809,7 +814,12 @@ const SupportWidget = () => {
                     <FaTicketAlt /> Create Ticket
                   </button>
                 )}
-                <button className={styles.callBtn} aria-label="Request phone call" tabIndex={0}>
+                <button 
+                  onClick={() => window.open('tel:+1-800-HEALCONNECT')}
+                  className={styles.callBtn} 
+                  aria-label="Request phone call" 
+                  tabIndex={0}
+                >
                   <FaPhone /> Request Call
                 </button>
               </div>
@@ -817,6 +827,7 @@ const SupportWidget = () => {
           </>
         )}
       </motion.div>
+      )}
 
       {/* Ticket Modal */}
       <AnimatePresence>
@@ -826,7 +837,10 @@ const SupportWidget = () => {
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             className={styles.modalOverlay}
-            onClick={() => setShowTicketModal(false)}
+            onClick={() => {
+              setShowTicketModal(false);
+              setSupportWidgetOpen(false);
+            }}
             role="dialog"
             aria-modal="true"
             aria-labelledby="modal-title"
@@ -846,7 +860,10 @@ const SupportWidget = () => {
                   Create Support Ticket
                 </h2>
                 <button
-                  onClick={() => setShowTicketModal(false)}
+                  onClick={() => {
+                    setShowTicketModal(false);
+                    setSupportWidgetOpen(false);
+                  }}
                   className={styles.closeModal}
                   aria-label="Close ticket creation modal"
                   tabIndex={0}
@@ -964,7 +981,10 @@ const SupportWidget = () => {
                   <div className={styles.formActions}>
                     <button
                       type="button"
-                      onClick={() => setShowTicketModal(false)}
+                      onClick={() => {
+                        setShowTicketModal(false);
+                        setSupportWidgetOpen(false);
+                      }}
                       className={styles.cancelBtn}
                       aria-label="Cancel ticket creation"
                     >

--- a/context/ThemeContext.jsx
+++ b/context/ThemeContext.jsx
@@ -9,6 +9,7 @@ export function ThemeProvider({ children }) {
   const [mounted, setMounted] = useState(false)
   const [isMinimized, setIsMinimized] = useState(false)
   const [supportWidgetOpen, setSupportWidgetOpen] = useState(false)
+  const [showTicketModal, setShowTicketModal] = useState(false);
   useEffect(() => {
     setMounted(true)
     const savedTheme = localStorage.getItem('theme')
@@ -44,7 +45,8 @@ export function ThemeProvider({ children }) {
   }
 
   return (
-    <ThemeContext.Provider value={{ theme, toggleTheme, isMinimized, setIsMinimized, supportWidgetOpen, setSupportWidgetOpen }}>
+    <ThemeContext.Provider value={{ theme, toggleTheme, isMinimized, setIsMinimized, supportWidgetOpen, setSupportWidgetOpen, showTicketModal,
+  setShowTicketModal }}>
       {children}
     </ThemeContext.Provider>
   )

--- a/pages/support.js
+++ b/pages/support.js
@@ -18,7 +18,8 @@ const Support = () => {
     activeAgents: 0
   });
 
-  const { setIsMinimized, setSupportWidgetOpen } = useTheme();
+  
+const { setIsMinimized, setSupportWidgetOpen, setShowTicketModal } = useTheme();
 
   useEffect(() => {
     // Mock stats - in production, fetch from your backend
@@ -275,7 +276,11 @@ const Support = () => {
                 <span>✓ Instant responses</span>
                 <span>✓ Free to use</span>
               </div>
-              <button className={styles.channelBtn}>Start Chat</button>
+              <button className={styles.channelBtn} 
+              onClick={() => {
+              setIsMinimized(false);
+              setSupportWidgetOpen(true);
+              }}>Start Chat</button>
             </motion.div>
 
             <motion.div
@@ -293,7 +298,13 @@ const Support = () => {
                 <span>✓ Priority handling</span>
                 <span>✓ Email updates</span>
               </div>
-              <button className={styles.channelBtn}>Create Ticket</button>
+              <button className={styles.channelBtn} 
+              onClick={() => {
+              setSupportWidgetOpen(true);
+              setIsMinimized(true);
+              setShowTicketModal(true);
+              }}
+              >Create Ticket</button>
             </motion.div>
 
             <motion.div
@@ -311,7 +322,7 @@ const Support = () => {
                 <span>✓ Complex issues</span>
                 <span>✓ Emergency support</span>
               </div>
-              <button className={styles.channelBtn}>Call Now</button>
+              <button className={styles.channelBtn} onClick={() => window.open('tel:+18001234567')} >Call Now</button>
             </motion.div>
 
             <motion.div


### PR DESCRIPTION
## 📝 Description
This PR addresses several functional issues in the Support Center where various channel buttons were non-responsive. I have integrated the Create Ticket, AI Assistant, and Live Chat buttons with the SupportWidget via the shared ThemeContext to ensure they trigger the correct UI flows. Additionally, I implemented direct dialing for the Phone Support button using the tel: protocol.

**Linked Issue:** #514 

## 🏗️ Type of Change
Select the relevant option:
- [ ] 🚀 **New Feature** (Addition of a new functionality)
- [ ✓] 🐛 **Bug Fix** (Logic or functional error)
- [ ] 🎨 **UI/UX Update** (Changes to the interface/accessibility)
- [ ] 📝 **Documentation** (README or Wiki updates)
- [ ] 🔧 **Refactor/Cleanup** (No functional changes)

---

## ⚙️ Technical Checklist
- [ ✓] I have read the [Contributing Guidelines](CONTRIBUTING.md).
- [✓ ] My code follows the project's style guidelines and PEP 8.
- [ ✓] **Firebase/Auth:** If I modified backend logic, I have verified it works.
- [✓ ] I have performed a self-review and added comments to complex code.
- [✓ ] My changes generate no new warnings or errors.

---

## 🧪 Testing & Evidence
- **Test Environment:** Windows 11
- **Results:** 1. Clicking Create Ticket on the support page now bypasses the chat history and opens the ticket dialog directly.
                      2. Clicking Call Now triggers the device's native phone dialer.
                      3. Clicking Start Live Chat correctly expands the AI Assistant widget.

---

## 📸 Screenshots / Media

https://github.com/user-attachments/assets/1cd3bf37-ae4c-4767-94d4-bc4b9615a23e

---

## ❄️ SWOC '26 Status
- [ ✓] I am a contributor for **Social Winter of Code 2026**.
- [✓ ] This is my first contribution to this project.

---
*By submitting this PR, I agree to maintain the standards of Chameleon. 🦎*
