### PR TITLE
Fix appointments header overlap and theme-aware styling

### DIFF
--- a/pages/Appointments.module.css
+++ b/pages/Appointments.module.css
@@ -170,6 +170,8 @@
   text-align: center;
   margin-bottom: 1rem;
   color: rgb(var(--foreground-rgb)) !important;
+  align-self: center;
+  width: 100%;
 }
 
 .sectionSubtitle {
@@ -311,15 +313,14 @@
 
 .bookingHeader {
   margin-bottom: 2rem;
-  position: relative;
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
 }
 
 /* FIX: Removed hardcoded light-mode colors — now theme-aware */
 .backButton {
-  position: absolute;
-  left: 0;
-  top: 0;
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -331,6 +332,8 @@
   cursor: pointer;
   transition: all 0.3s ease;
   font-weight: 500;
+  margin-bottom: 1.5rem;
+  width: fit-content;
 }
 
 .backButton:hover {
@@ -346,6 +349,9 @@
 .selectedDoctorSpecialty {
   color: rgb(var(--foreground-muted-rgb));
   font-size: 1.1rem;
+  text-align: center;
+  align-self: center;
+  width: 100%;
 }
 
 .bookingContent {


### PR DESCRIPTION
## 📝 Description
Fixes the overlapping UI elements on the Appointments booking page where the back button was positioned on top of the section heading.
**Linked Issue:** #515 

## 🏗️ Type of Change
Select the relevant option:
- [ ] 🚀 **New Feature** (Addition of a new functionality)
- [ ] 🐛 **Bug Fix** (Logic or functional error)
- [✓ ] 🎨 **UI/UX Update** (Changes to the interface/accessibility)
- [ ] 📝 **Documentation** (README or Wiki updates)
- [ ] 🔧 **Refactor/Cleanup** (No functional changes)

---

## ⚙️ Technical Checklist
- [✓ ] I have read the [Contributing Guidelines](CONTRIBUTING.md).
- [ ✓] My code follows the project's style guidelines and PEP 8.
- [✓ ] **Firebase/Auth:** If I modified backend logic, I have verified it works.
- [✓ ] I have performed a self-review and added comments to complex code.
- [✓ ] My changes generate no new warnings or errors.

---

## 🧪 Testing & Evidence
- **Test Environment:** Windows 11
- **Results:** (Describe what happened when you ran the code)

---

## 📸 Screenshots / Media
<img width="515" height="746" alt="Screenshot 2026-02-21 045729" src="https://github.com/user-attachments/assets/8883bae3-aa9b-430d-b008-ae746a0df2e5" />

---

## ❄️ SWOC '26 Status
- [✓ ] I am a contributor for **Social Winter of Code 2026**.
- [ ] This is my first contribution to this project.

---
*By submitting this PR, I agree to maintain the standards of Chameleon. 🦎*
