### PR TITLE
Fix: Reset scroll position on navigation

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -54,7 +54,10 @@ function MyApp({ Component, pageProps }) {
 
   useEffect(() => {
     const handleStart = () => setIsRouteLoading(true)
-    const handleEnd = () => setIsRouteLoading(false)
+    const handleEnd = () => {
+      setIsRouteLoading(false)
+      window.scrollTo(0, 0)
+    }
 
     router.events.on('routeChangeStart', handleStart)
     router.events.on('routeChangeComplete', handleEnd)


### PR DESCRIPTION
Fixes #520. Adds a global scroll reset to \_app.js\ on route change completion to ensure pages always load at the top.