### PR TITLE
Fix: UI Overlap in Mobile Appointments View

### DIFF
--- a/pages/appointments.jsx
+++ b/pages/appointments.jsx
@@ -518,12 +518,13 @@ export default function Appointments() {
               exit="hidden"
               variants={scaleIn}
             >
-              <div className={styles.bookingHeader}>
+              <div className={styles.bookingHeader} style={{ paddingTop: '2.5rem', position: 'relative' }}>
                 <motion.button
                   onClick={handleBackToDoctors}
                   className={styles.backButton}
                   whileHover={{ x: -5 }}
                   whileTap={{ scale: 0.95 }}
+                  style={{ position: 'absolute', top: 0, left: 0 }}
                 >
                   <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M15 18L9 12L15 6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />


### PR DESCRIPTION
Closes #515. Added local padding and position constraints to the bookingHeader header to push the doctor's name beneath the absolutely positioned Back navigation element on smaller screens.