### PR TITLE
Fix: Support Page Content Hidden Under Fixed Header (Title Bar Overlap)

### DIFF
--- a/pages/support.module.css
+++ b/pages/support.module.css
@@ -1,5 +1,7 @@
 /* Support Page Styles */
 .supportPage {
+    padding-top: 90px; /* FIX: prevents content from hiding under fixed header */
+
   min-height: 100vh;
   background: #f8fafc;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;


### PR DESCRIPTION
## 📝 Description
This PR fixes the layout issue where the Support page content was partially hidden beneath the fixed navbar/title bar on initial load. The hero section and top stats cards were starting behind the header, reducing visibility and negatively impacting user experience.

Changes Made:
Added top spacing to the main .supportPage container in support.module.css
Applied padding-top equal to the fixed header height to prevent overlap
Ensured the hero section, stats cards, and dashboard content now render fully below the navbar
Maintained existing layout, animations, and responsiveness (no functional changes)

**Linked Issue:** ---
Closes #538  

## 🏗️ Type of Change
Select the relevant option:
- [ ] 🚀 **New Feature** (Addition of a new functionality)
- [ ] 🐛 **Bug Fix** (Logic or functional error)
- [ ] 🎨 **UI/UX Update** (Changes to the interface/accessibility)
- [ ] 📝 **Documentation** (README or Wiki updates)
- [ ] 🔧 **Refactor/Cleanup** (No functional changes)

---

## ⚙️ Technical Checklist
- [ ] I have read the [Contributing Guidelines](CONTRIBUTING.md).
- [ ] My code follows the project's style guidelines and PEP 8.
- [ ] **Firebase/Auth:** If I modified backend logic, I have verified it works.
- [ ] I have performed a self-review and added comments to complex code.
- [ ] My changes generate no new warnings or errors.

---

## 🧪 Testing & Evidence
- **Test Environment:** (e.g., Windows 11, Python 3.12)
- **Results:** (Describe what happened when you ran the code)

---

## 📸 Screenshots / Media
<img width="1919" height="1015" alt="Screenshot 2026-02-28 212450" src="https://github.com/user-attachments/assets/f6c4caf5-5319-446c-a6e9-18da100269ee" />


## ❄️ SWOC '26 Status
- [x] I am a contributor for **Social Winter of Code 2026**.
- [ ] This is my first contribution to this project.

---
*By submitting this PR, I agree to maintain the standards of Chameleon. 🦎*
