### PR TITLE
fix(alertSystem): resolve race condition in alert generation bypassin…

### DIFF
--- a/lib/alertSystem.js
+++ b/lib/alertSystem.js
@@ -1,5 +1,5 @@
 // Alert system for monitoring patient vitals and generating emergency notifications
-import { collection, addDoc, query, where, getDocs, orderBy, limit, Timestamp } from 'firebase/firestore';
+import { collection, addDoc, query, where, getDocs, orderBy, limit, Timestamp, doc, runTransaction } from 'firebase/firestore';
 import { db } from './firebase';
 import { isVitalNormal, parseBloodPressure, DEFAULT_THRESHOLDS } from './thresholdDefaults';
 import logger from './logger';
@@ -190,17 +190,62 @@ export async function monitorAndAlert(patientData) {
 
     const createdAlerts = [];
 
-    // Create alerts, but check for recent duplicates first
+    // Create alerts using a transaction to prevent race conditions bypassing rate limits
     for (const alert of alerts) {
-        const hasRecent = await hasRecentAlert(alert.patientId, alert.vitalType);
+        try {
+            const patientRef = doc(db, 'patients', alert.patientId);
+            const alertsColRef = collection(db, 'alerts');
+            const newAlertRef = doc(alertsColRef);
 
-        if (!hasRecent) {
-            const result = await saveAlert(alert);
-            if (result.success) {
-                createdAlerts.push(result.alert);
-            }
-        } else {
-            logger.debug(`Skipping duplicate alert for ${patientName}: ${alert.vitalName}`);
+            await runTransaction(db, async (transaction) => {
+                const patientDoc = await transaction.get(patientRef);
+                
+                let lastAlertTimestamps = {};
+                if (patientDoc.exists() && patientDoc.data().lastAlertTimestamps) {
+                    lastAlertTimestamps = patientDoc.data().lastAlertTimestamps;
+                }
+
+                const vitalType = alert.vitalType;
+                const now = Timestamp.now();
+                const minutesAgo = 15;
+                const cutoffTime = new Date();
+                cutoffTime.setMinutes(cutoffTime.getMinutes() - minutesAgo);
+                
+                // Verify 15-minute gap
+                if (lastAlertTimestamps[vitalType]) {
+                    const lastAlertTime = lastAlertTimestamps[vitalType].toDate();
+                    if (lastAlertTime > cutoffTime) {
+                        logger.debug(`Skipping duplicate alert (transaction lock) for ${patientName}: ${alert.vitalName}`);
+                        return; // Exit transaction early, bypassing write
+                    }
+                }
+
+                // Prepare alert document
+                const alertDocData = {
+                    ...alert,
+                    acknowledged: false,
+                    acknowledgedAt: null,
+                    acknowledgedBy: null,
+                    createdAt: now,
+                    createdAtReadable: new Date().toLocaleString(),
+                    isGlobal: alert.isGlobal || false
+                };
+                
+                // Write the alert
+                transaction.set(newAlertRef, alertDocData);
+
+                // Update the generic patient document with the new concurrency lock timestamp
+                lastAlertTimestamps[vitalType] = now;
+                
+                transaction.set(patientRef, {
+                    lastAlertTimestamps: lastAlertTimestamps
+                }, { merge: true });
+
+                createdAlerts.push({ id: newAlertRef.id, ...alertDocData });
+            });
+        } catch (error) {
+            console.error('Transaction failed for alert generation:', error);
+            logger.error(`Transaction failed for ${patientName} (${alert.vitalName}): ${error.message}`);
         }
     }
 


### PR DESCRIPTION
…g rate limits

Wrapped exactly-once alert generation logic within a Firestore runTransaction using a generic patient timestamp lock.



#657 

## Description
This PR addresses a critical architectural flaw where high-frequency database writes bypass the 15-minute duplicate safeguard within [monitorAndAlert](cci:1://file:///d:/OSCG/hsdg/HEALCONNECT/lib/alertSystem.js:178:0-257:1) due to a lack of atomicity. 

Previously, when concurrent vital points crossed thresholds (e.g., via websockets/ESP32), [hasRecentAlert](cci:1://file:///d:/OSCG/hsdg/HEALCONNECT/lib/alertSystem.js:154:0-176:1) evaluated to false simultaneously for multiple instances, resulting in alert spam. 

This PR wraps the exactly-once delivery logic inside a unified Firestore `runTransaction`. It utilizes a centralized concurrency lock (`lastAlertTimestamps`) on the `patient` document to guarantee atomic reads and writes, successfully enforcing the 15-minute cooldown.

## Changes Made
- Deprecated the sequential [hasRecentAlert](cci:1://file:///d:/OSCG/hsdg/HEALCONNECT/lib/alertSystem.js:154:0-176:1) check followed by [saveAlert](cci:1://file:///d:/OSCG/hsdg/HEALCONNECT/lib/alertSystem.js:129:0-152:1) within the loop inside [monitorAndAlert](cci:1://file:///d:/OSCG/hsdg/HEALCONNECT/lib/alertSystem.js:178:0-257:1).
- Refactored [monitorAndAlert](cci:1://file:///d:/OSCG/hsdg/HEALCONNECT/lib/alertSystem.js:178:0-257:1) to use a Firestore `runTransaction`.
- Added a `lastAlertTimestamps` map on the patient's root document.
- The transaction now atomically calculates the 15-minute gap logic against `lastAlertTimestamps[vitalType]` to authorize and execute the alert append and timestamp update as a single batch operation.

## How to Test
1. Connect a hardware device (ESP32) and trigger a critical threshold rapidly.
2. Ensure multiple database write events fire within a small window (<50ms).
3. Observe the `alerts` collection.
4. Verify that only **one** alert is written to the database for that specific vital type within the 15-minute window, and duplicate requests are safely rejected.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Architecture enhancement (handling transactional integrity)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The 15-minute cooldown logic is exactly-once guaranteed

