### PR TITLE
fix(api): resolve critical IDOR/RBAC vulnerability in patients API

### DIFF
--- a/pages/api/patients/index.js
+++ b/pages/api/patients/index.js
@@ -42,13 +42,22 @@ async function getPatients(req, res) {
 
   const constraints = [];
 
-  // Security: If user is a doctor, force them to see only their patients?
-  // For now, if doctorId is provided, filter by it.
-  // Ideally, req.user.uid should be used if the user IS a doctor.
+  // Enforce RBAC
+  const user = req.user;
 
-  if (doctorId) {
-    constraints.push(where('doctorId', '==', doctorId));
+  if (user.role === 'doctor') {
+    // Force constraint to filter strictly by the doctor's uid
+    constraints.push(where('doctorId', '==', user.uid));
+  } else if (user.role === 'admin') {
+    // Admins can provide a filter
+    if (doctorId) {
+      constraints.push(where('doctorId', '==', doctorId));
+    }
+  } else {
+    // Reject unauthorized cross-access
+    return res.status(403).json({ success: false, message: 'Forbidden: Insufficient privileges to access patient records.' });
   }
+
   if (status) {
     constraints.push(where('status', '==', status));
   }


### PR DESCRIPTION
Enforce strict req.user.uid authorization instead of trusting client-provided doctorId parameter.


#656 

## Description

**Context:**
A critical security vulnerability (IDOR) existed in the [pages/api/patients/index.js](cci:7://file:///d:/OSCG/jsgd/HEALCONNECT/pages/api/patients/index.js:0:0-0:0) route. The handler was directly trusting a client-provided `doctorId` query parameter to filter and fetch sensitive records, completely bypassing server-side validation against the authenticated user’s session claims. 

**Changes Made:**
This PR enforces strict Role-Based Access Control (RBAC) at the handler level to ensure data isolation. 
- **Doctors:** Query is now hardcoded to enforce `doctorId === req.user.uid` strictly, completely ignoring any malicious query injections.
- **Administrators:** If `req.user.role === 'admin'`, the API still honors specific filtering queries allowing them to list cross-system patients.
- **Other Roles:** Any other standard user attempting to hit this endpoint is blocked out-right with a `403 Forbidden` response. 

## Related Issue
<!-- Closes #ISSUE_NUMBER_HERE -->

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔒 Security patch (fixes a critical vulnerability)

## How Has This Been Tested?
- [x] Authenticate as a normal user/patient and verify the endpoint correctly rejects the request with a `403 Forbidden`.
- [x] Authenticate as a doctor and confirm the server forces the filter down to `req.user.uid`, blocking access to other doctors' PHI databases.
- [x] Authenticate as an admin and verify cross-system queries (`?doctorId=...`) are still functionally serving data.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
