### PR TITLE
Fix alert timestamp updates with single transaction (Fixes #696)

### DIFF
--- a/__tests__/integration/alertSystem.test.js
+++ b/__tests__/integration/alertSystem.test.js
@@ -1,4 +1,4 @@
-import { checkPatientVitals } from '../../lib/alertSystem';
+import { checkPatientVitals, monitorAndAlert } from '../../lib/alertSystem';
 
 // Mock Firebase to avoid actual database calls
 jest.mock('../../lib/firebase', () => ({
@@ -13,8 +13,20 @@ jest.mock('firebase/firestore', () => ({
   getDocs: jest.fn(),
   orderBy: jest.fn(),
   limit: jest.fn(),
-  Timestamp: jest.fn(),
+  doc: jest.fn(),
+  runTransaction: jest.fn(),
+  Timestamp: {
+    now: jest.fn(),
+    fromDate: jest.fn(),
+  },
 }));
+
+const {
+  collection,
+  doc,
+  runTransaction,
+  Timestamp,
+} = require('firebase/firestore');
 
 describe('Alert System Integration', () => {
   beforeEach(() => {
@@ -143,5 +155,59 @@ describe('Alert System Integration', () => {
     expect(systolicAlert).toBeDefined();
     expect(systolicAlert.currentValue).toBe(160);
     expect(systolicAlert.severity).toBe('critical'); // 160 is above criticalMax of 140
+  });
+
+  test('uses a single transaction for multiple alerts in one monitoring cycle', async () => {
+    const nowValues = [
+      { toDate: () => new Date('2026-04-06T10:00:00Z') },
+      { toDate: () => new Date('2026-04-06T10:00:01Z') },
+    ];
+
+    Timestamp.now
+      .mockReturnValueOnce(nowValues[0])
+      .mockReturnValueOnce(nowValues[1]);
+
+    collection.mockImplementation((dbArg, name) => ({ dbArg, name }));
+    doc
+      .mockImplementationOnce((dbArg, name, id) => ({ path: `${name}/${id}` }))
+      .mockImplementationOnce(() => ({ id: 'alert-heart-rate' }))
+      .mockImplementationOnce(() => ({ id: 'alert-oxygen' }));
+
+    const transaction = {
+      get: jest.fn().mockResolvedValue({
+        exists: () => true,
+        data: () => ({ lastAlertTimestamps: {} }),
+      }),
+      set: jest.fn(),
+    };
+
+    runTransaction.mockImplementation(async (dbArg, callback) => callback(transaction));
+
+    const patientData = {
+      id: 'patient123',
+      name: 'Jane Smith',
+      doctorId: 'doctor456',
+      thresholds: {},
+      heartRate: 150,
+      oxygen: 85,
+    };
+
+    const result = await monitorAndAlert(patientData);
+
+    expect(runTransaction).toHaveBeenCalledTimes(1);
+    expect(transaction.get).toHaveBeenCalledTimes(1);
+    expect(transaction.set).toHaveBeenCalledTimes(3);
+    expect(transaction.set).toHaveBeenLastCalledWith(
+      { path: 'patients/patient123' },
+      {
+        lastAlertTimestamps: {
+          heartRate: nowValues[0],
+          oxygen: nowValues[1],
+        },
+      },
+      { merge: true }
+    );
+    expect(result.success).toBe(true);
+    expect(result.alertsCreated).toBe(2);
   });
 });

--- a/lib/alertSystem.js
+++ b/lib/alertSystem.js
@@ -222,39 +222,39 @@ export async function monitorAndAlert(patientIdOrData, specificVitals = null) {
             return { success: true, message: 'All vitals normal', alertsCreated: 0 };
         }
 
+        const patientRef = doc(db, 'patients', patientData.id);
+        const alertsColRef = collection(db, 'alerts');
         const createdAlerts = [];
 
-        // Create alerts using a transaction to prevent race conditions bypassing rate limits
-        for (const alert of alerts) {
-            try {
-                const patientRef = doc(db, 'patients', patientData.id);
-                const alertsColRef = collection(db, 'alerts');
-                const newAlertRef = doc(alertsColRef);
+        try {
+            const committedAlerts = await runTransaction(db, async (transaction) => {
+                const latestPatientDoc = await transaction.get(patientRef);
+                const existingLastAlertTimestamps =
+                    latestPatientDoc.exists() && latestPatientDoc.data().lastAlertTimestamps
+                        ? latestPatientDoc.data().lastAlertTimestamps
+                        : {};
 
-                await runTransaction(db, async (transaction) => {
-                    const latestPatientDoc = await transaction.get(patientRef);
+                const lastAlertTimestamps = { ...existingLastAlertTimestamps };
+                const pendingAlerts = [];
+                const minutesAgo = 15;
+                const cutoffTime = new Date();
+                cutoffTime.setMinutes(cutoffTime.getMinutes() - minutesAgo);
 
-                    let lastAlertTimestamps = {};
-                    if (latestPatientDoc.exists() && latestPatientDoc.data().lastAlertTimestamps) {
-                        lastAlertTimestamps = latestPatientDoc.data().lastAlertTimestamps;
-                    }
-
+                for (const alert of alerts) {
                     const vitalType = alert.vitalType;
-                    const now = Timestamp.now();
-                    const minutesAgo = 15;
-                    const cutoffTime = new Date();
-                    cutoffTime.setMinutes(cutoffTime.getMinutes() - minutesAgo);
+                    const lastAlertTimestamp = lastAlertTimestamps[vitalType];
 
-                    // Verify 15-minute gap
-                    if (lastAlertTimestamps[vitalType]) {
-                        const lastAlertTime = lastAlertTimestamps[vitalType].toDate();
+                    // Verify 15-minute gap against the latest committed state in this transaction.
+                    if (lastAlertTimestamp) {
+                        const lastAlertTime = lastAlertTimestamp.toDate();
                         if (lastAlertTime > cutoffTime) {
                             logger.debug(`Skipping duplicate alert for ${patientName}: ${alert.vitalName}`);
-                            return; 
+                            continue;
                         }
                     }
 
-                    // Prepare alert document
+                    const now = Timestamp.now();
+                    const newAlertRef = doc(alertsColRef);
                     const alertDocData = {
                         ...alert,
                         acknowledged: false,
@@ -265,22 +265,24 @@ export async function monitorAndAlert(patientIdOrData, specificVitals = null) {
                         isGlobal: alert.isGlobal || false
                     };
 
-                    // Write the alert
                     transaction.set(newAlertRef, alertDocData);
-
-                    // Update the generic patient document with the new concurrency lock timestamp
                     lastAlertTimestamps[vitalType] = now;
+                    pendingAlerts.push({ id: newAlertRef.id, ...alertDocData });
+                }
 
+                if (pendingAlerts.length > 0) {
                     transaction.set(patientRef, {
-                        lastAlertTimestamps: lastAlertTimestamps
+                        lastAlertTimestamps
                     }, { merge: true });
+                }
 
-                    createdAlerts.push({ id: newAlertRef.id, ...alertDocData });
-                });
-            } catch (error) {
-                console.error('Transaction failed for alert generation:', error);
-                logger.error(`Transaction failed for ${patientName} (${alert.vitalName}): ${error.message}`);
-            }
+                return pendingAlerts;
+            });
+
+            createdAlerts.push(...committedAlerts);
+        } catch (error) {
+            console.error('Transaction failed for alert generation:', error);
+            logger.error(`Transaction failed for ${patientName}: ${error.message}`);
         }
 
         return {


### PR DESCRIPTION
## Summary                                                                             
                                                                                         
  Fix alert generation so a single patient monitoring cycle uses one Firestore           
  transaction instead of one transaction per critical vital.                             
                                                                                         
  Previously, when multiple vitals breached thresholds in the same monitoring event, the 
  system executed `runTransaction(...)` inside a loop. That caused multiple transactions 
  to compete on the same patient document (`lastAlertTimestamps`), which increased       
  contention and could leave the patient document partially updated if one transaction   
  succeeded and a later one failed.                                                      
                                                                                         
  This change batches all alert writes and all `lastAlertTimestamps` updates into one    
  atomic transaction per monitoring cycle.                                               
                                                                                         
  ## Problem                                                                             
                                                                                         
  The old flow effectively looked like this:                                             
                                                                                         
  ```js                                                                                  
  for (const alert of alerts) {
    await runTransaction(db, async (transaction) => {                                    
      // read patient doc                                                                
      // update one vital timestamp                                                      
      // write one alert                                                                 
    });                                                                                  
  }                                                                                      
                                                                                         
  That created two reliability issues:                                                   
                                                                                         
  1. Transaction contention                                                              
      - Multiple transactions targeted the same patient document in quick succession     
      - Firestore had to retry conflicting transactions                                  
      - This increased latency, retries, and backend load                                
  2. Broken atomicity                                                                    
      - One monitoring event could be partially committed                                
      - Example: heartRate timestamp updates successfully, but oxygen timestamp update   
        fails                                                                            
      - lastAlertTimestamps becomes inconsistent for the same monitoring cycle           
                                                                                         
  ## Fix                                                                                 
                                                                                         
  Updated monitorAndAlert to:                                                            
                                                                                         
  1. Evaluate all generated alerts first                                                 
  2. Open a single Firestore transaction for the patient monitoring cycle                
  3. Read lastAlertTimestamps once                                                       
  4. Check duplicate suppression for each alert within that same transaction             
  5. Create all alert documents inside the transaction                                   
  6. Write one merged lastAlertTimestamps update at the end                              
  7. Commit all changes together or not at all                                           
                                                                                         
  ## What changed                                                                        
                                                                                         
  - Replaced per-alert transaction execution with one transaction per monitoring event   
  - Consolidated all lastAlertTimestamps changes into one merged update                  
  - Preserved duplicate-alert suppression logic                                          
  - Moved createdAlerts accumulation out of the transaction callback so transaction      
    retries do not cause incorrect side effects                                          
  - Added a regression test to verify multiple alerts in one monitoring cycle use a      
    single transaction                                                                   
                                                                                         
  ## Files changed                                                                       
                                                                                         
  - lib/alertSystem.js                                                                   
  - __tests__/integration/alertSystem.test.js                                            
                                                                                         
  ## Expected impact                                                                     
                                                                                         
  - Reduced Firestore transaction contention on patient documents                        
  - Lower retry overhead during concurrent critical alert handling                       
  - Restored atomicity for a single monitoring event                                     
  - Prevented partial persistence of alert timestamps                                    
  - Improved consistency for future duplicate-alert checks                               
                                                                                         
  ## Testing                                                                             
                                                                                         
  Implemented:                                                                           
                                                                                         
  - Regression test covering multiple alerts in one monitoring cycle and asserting a     
    single runTransaction call                                                           
                                                                                         
  Verification note:                                                                     
                                                                                         
  - node --check lib/alertSystem.js passed                                               
  - Local Jest execution is currently blocked by repo test environment setup (npx jest   
    pulled Jest 30 and failed because jest-environment-jsdom is not available in the     
    current project setup)                                                               
                           