### PR TITLE
fix: add error handling to ChatBox handleSend to prevent UI freeze

### DIFF
--- a/components/Chat/ChatBox.jsx
+++ b/components/Chat/ChatBox.jsx
@@ -59,17 +59,29 @@ export default function ChatBox() {
 
     // Simulate AI response delay
     setTimeout(() => {
-      const response = generateAIResponse(text);
-      const aiMessage = {
-        id: (Date.now() + 1).toString(),
-        text: response.text,
-        sender: 'ai',
-        timestamp: new Date().toISOString(),
-        isEmergency: response.isEmergency,
-        isTip: response.isTip
-      };
-      setMessages(prev => [...prev, aiMessage]);
-      setIsTyping(false);
+      try {
+        const response = generateAIResponse(text);
+        const aiMessage = {
+          id: (Date.now() + 1).toString(),
+          text: response.text,
+          sender: 'ai',
+          timestamp: new Date().toISOString(),
+          isEmergency: response.isEmergency,
+          isTip: response.isTip
+        };
+        setMessages(prev => [...prev, aiMessage]);
+      } catch (error) {
+        console.error("AI processing error:", error);
+        const errorMessage = {
+          id: (Date.now() + 1).toString(),
+          text: "Sorry, I encountered an error processing your request.",
+          sender: 'ai',
+          timestamp: new Date().toISOString()
+        };
+        setMessages(prev => [...prev, errorMessage]);
+      } finally {
+        setIsTyping(false);
+      }
     }, 1000 + Math.random() * 1000);
   };
 


### PR DESCRIPTION

#729 

### 🐛 Description
Currently, in `components/Chat/ChatBox.jsx`, the `handleSend` function generates the AI response inside a `setTimeout`. However, there was no error handling around the `generateAIResponse(text)` function call. If the AI engine encountered an error or failed, the application threw an unhandled exception, and the `isTyping` state remained `true` forever. This permanently froze the chat UI with the typing indicator spinning, preventing the user from sending further messages without refreshing the page.

### 🛠️ Proposed Changes
- Wrapped the AI response generation logic inside a `try...catch...finally` block.
- Added a `catch` block that appends a graceful fallback system message ("Sorry, I encountered an error processing your request.") to inform the user.
- Utilized the `finally` block to guarantee `setIsTyping(false)` is always executed, restoring the chat input state regardless of a success or failure outcome.

### 📁 File(s) Modified
- `components/Chat/ChatBox.jsx`

### 🧪 Steps to Verify
1. Open the Medical AI Chat interface in your browser.
2. Force `generateAIResponse` to throw an error (or simulate a network failure/API timeout).
3. Send a message.
4. Verify that the "Typing..." indicator spins briefly, disappears, and an error message bubble correctly appears without locking up the chat input.
