### PR TITLE
fix: resolve production Tailwind CSS compilation bug in contact categ…

### DIFF
--- a/pages/contact.js
+++ b/pages/contact.js
@@ -42,6 +42,34 @@ const staggerContainer = {
   },
 };
 
+const categoryStyles = {
+  blue: {
+    button: "border-blue-500 bg-blue-50 dark:bg-blue-900/20",
+    icon: "text-blue-600 dark:text-blue-400",
+    text: "text-blue-700 dark:text-blue-300",
+  },
+  orange: {
+    button: "border-orange-500 bg-orange-50 dark:bg-orange-900/20",
+    icon: "text-orange-600 dark:text-orange-400",
+    text: "text-orange-700 dark:text-orange-300",
+  },
+  green: {
+    button: "border-green-500 bg-green-50 dark:bg-green-900/20",
+    icon: "text-green-600 dark:text-green-400",
+    text: "text-green-700 dark:text-green-300",
+  },
+  red: {
+    button: "border-red-500 bg-red-50 dark:bg-red-900/20",
+    icon: "text-red-600 dark:text-red-400",
+    text: "text-red-700 dark:text-red-300",
+  },
+  purple: {
+    button: "border-purple-500 bg-purple-50 dark:bg-purple-900/20",
+    icon: "text-purple-600 dark:text-purple-400",
+    text: "text-purple-700 dark:text-purple-300",
+  },
+};
+
 export default function Contact() {
   const router = useRouter();
   const [formData, setFormData] = useState({
@@ -641,19 +669,19 @@ export default function Contact() {
                               }))
                             }
                             className={`p-3 rounded-lg border-2 transition-all duration-200 flex flex-col items-center gap-2 ${formData.category === category.value
-                              ? `border-${category.color}-500 bg-${category.color}-50 dark:bg-${category.color}-900/20`
+                              ? categoryStyles[category.color]?.button
                               : "border-gray-400 dark:border-gray-600 hover:border-gray-500 dark:hover:border-gray-500"
                               }`}
                           >
                             <Icon
                               className={`text-xl ${formData.category === category.value
-                                ? `text-${category.color}-600 dark:text-${category.color}-400`
+                                ? categoryStyles[category.color]?.icon
                                 : "text-gray-400 dark:text-gray-500"
                                 }`}
                             />
                             <span
                               className={`text-xs font-medium ${formData.category === category.value
-                                ? `text-${category.color}-700 dark:text-${category.color}-300`
+                                ? categoryStyles[category.color]?.text
                                 : "text-gray-600 dark:text-gray-400"
                                 }`}
                             >


### PR DESCRIPTION
…ories

#743 

### Summary
Fixes a production styling issue where the contact page category selection buttons lose their background, border, and text colors.

### Root Cause
Tailwind CSS scans source files statically to build the final production stylesheet. Dynamic class name interpolation like `border-${category.color}-500`, `bg-${category.color}-50`, `text-${category.color}-600`, etc., cannot be resolved statically by the Tailwind compiler. Consequently, the compiler prunes these dynamic classes during the production build.

### Changes
- Introduced a static `categoryStyles` configuration mapping colors (`blue`, `orange`, `green`, `red`, `purple`) directly to their complete Tailwind class strings in `pages/contact.js`.
- Refactored the category selection button container, icon, and label elements to fetch class names statically via `categoryStyles[category.color]`.

### Verification
- Verified that class names are now fully specified in the file (e.g., `"border-blue-500 bg-blue-50 dark:bg-blue-900/20"`), allowing Tailwind CSS to correctly index and bundle them for production.
